### PR TITLE
enable to analysis dir usage

### DIFF
--- a/CITA_Monitor_Agent_Docker/DockerCompose_Files/.env
+++ b/CITA_Monitor_Agent_Docker/DockerCompose_Files/.env
@@ -24,3 +24,6 @@ target_port=1337
 # CITA node directory analysis
 # Support multiple directories, split by ',' 
 node_dir=/github/cita_secp256k1_sha3/monitor_chain_02/0
+
+# CITA node id
+node_id=0

--- a/CITA_Monitor_Agent_Docker/DockerCompose_Files/.env
+++ b/CITA_Monitor_Agent_Docker/DockerCompose_Files/.env
@@ -1,5 +1,5 @@
 # container hostname
-hostname=EP_Host_01
+hostname=EP_Host_192_168_2_174
 
 # prometheus_node_exporter outside port and inside port
 node_out_port=9100
@@ -20,3 +20,7 @@ agent_in_port=1920
 # CITA node target ip and port
 target_ip=192.168.2.174
 target_port=1337
+
+# CITA node directory analysis
+# Support multiple directories, split by ',' 
+node_dir=/github/cita_secp256k1_sha3/monitor_chain_02/0

--- a/CITA_Monitor_Agent_Docker/DockerCompose_Files/docker-compose.yml
+++ b/CITA_Monitor_Agent_Docker/DockerCompose_Files/docker-compose.yml
@@ -40,6 +40,9 @@ services:
                   pid: "host"
                   ports:
                           - "${agent_out_port}:${agent_in_port}"
+                  volumes:
+                          - "${node_dir}:${node_dir}:ro"
                   environment:
                           - "Node=${target_ip}:${target_port}"
                           - "OpenPort=${agent_in_port}"
+                          - "Dir=${node_dir}"

--- a/CITA_Monitor_Agent_Docker/DockerCompose_Files/docker-compose.yml
+++ b/CITA_Monitor_Agent_Docker/DockerCompose_Files/docker-compose.yml
@@ -46,3 +46,4 @@ services:
                           - "Node=${target_ip}:${target_port}"
                           - "OpenPort=${agent_in_port}"
                           - "Dir=${node_dir}"
+                          - "NodeID=${node_id}"

--- a/CITA_Monitor_Agent_Docker/DockerCompose_Files/docker-compose.yml
+++ b/CITA_Monitor_Agent_Docker/DockerCompose_Files/docker-compose.yml
@@ -1,9 +1,9 @@
 version: "3"
 services:
-          prometheus_node_exporter:
+          prometheus_host_exporter:
                   image: prom/node-exporter
                   hostname: ${hostname}
-                  container_name: prometheus_node_exporter
+                  container_name: prometheus_host_exporter
                   ports:
                           - "${node_out_port}:${node_in_port}"
                   volumes:

--- a/CITA_Monitor_Agent_Docker/DockerImage_Build_Files/Dockerfile
+++ b/CITA_Monitor_Agent_Docker/DockerImage_Build_Files/Dockerfile
@@ -9,5 +9,6 @@ RUN pip3 install -r requirements.txt
 RUN mv cita-cli /bin/cita-cli && chmod +x /bin/cita-cli
 ENV OpenPort=1920
 ENV Dir='/tmp'
+ENV NodeID=0
 ## 运行命令
-CMD "python3" "cita_agent_by_cita-cli.py" "$Node" "$OpenPort" "$Dir"
+CMD "python3" "cita_agent_by_cita-cli.py" "$Node" "$OpenPort" "$Dir" "$NodeID"

--- a/CITA_Monitor_Agent_Docker/DockerImage_Build_Files/Dockerfile
+++ b/CITA_Monitor_Agent_Docker/DockerImage_Build_Files/Dockerfile
@@ -8,5 +8,6 @@ ADD . /config
 RUN pip3 install -r requirements.txt
 RUN mv cita-cli /bin/cita-cli && chmod +x /bin/cita-cli
 ENV OpenPort=1920
+ENV Dir='/tmp'
 ## 运行命令
-CMD "python3" "cita_agent_by_cita-cli.py" "$Node" "$OpenPort"
+CMD "python3" "cita_agent_by_cita-cli.py" "$Node" "$OpenPort" "$Dir"

--- a/CITA_Monitor_Agent_Docker/DockerImage_Build_Files/cita_agent_by_cita-cli.py
+++ b/CITA_Monitor_Agent_Docker/DockerImage_Build_Files/cita_agent_by_cita-cli.py
@@ -11,6 +11,7 @@ import sys
 ##########
 Node = sys.argv[1]
 receive_path = sys.argv[3]
+node_id = sys.argv[4]
 ##########
 NodeFlask = Flask(__name__)
 ##########
@@ -87,11 +88,11 @@ def Node_Get():
                                 registry=CITA_Chain)
     Node_Get_LastBlocknumber = Gauge("Node_Get_LastBlocknumber",
                                      "Get the latest block height;",
-                                     ["NodeIP", "NodePort", "FirstBlocknumberHash"],
+                                     ["NodeIP", "NodePort", "FirstBlocknumberHash", "NodeID"],
                                      registry=CITA_Chain)
     Node_Get_LastBlocknumberDetails = Gauge("Node_Get_LastBlocknumberDetails",
                                             "Get the hash and timestamp of the last block;",
-                                            ["NodeIP", "NodePort", "LastBlocknumber", "LastBlocknumberInt","LastBlocknumberHash"],
+                                            ["NodeIP", "NodePort", "LastBlocknumber", "LastBlocknumberInt", "LastBlocknumberHash", "NodeID"],
                                             registry=CITA_Chain)
     Node_Get_DirInfo_TotalFileSize = Gauge("Node_Get_DirInfo_TotalFileSize",
                              "Get TotalFileSize by Node Dir;",
@@ -136,12 +137,12 @@ def Node_Get():
         Node_Get_LastBlocknumber_by_blockNumber = GetResult.blockNumber()
         if Node_Get_LastBlocknumber_by_blockNumber != -99:
             Blocknumber = Node_Get_LastBlocknumber_by_blockNumber['result']
-            Node_Get_LastBlocknumber.labels(NodeIP=NodeIP, NodePort=NodePort, FirstBlocknumberHash=FirstBlocknumberHash).set(int(Blocknumber,16))
+            Node_Get_LastBlocknumber.labels(NodeIP=NodeIP, NodePort=NodePort, FirstBlocknumberHash=FirstBlocknumberHash, NodeID=node_id).set(int(Blocknumber,16))
         Node_Get_LastBlocknumberDetails_by_getBlockByNumber = GetResult.getBlockByNumber(Blocknumber)
         if Node_Get_LastBlocknumberDetails_by_getBlockByNumber != -99:
             LastBlocknumberHash = Node_Get_LastBlocknumberDetails_by_getBlockByNumber['result']['hash']
             LastBlocknumberTimestamp = Node_Get_LastBlocknumberDetails_by_getBlockByNumber['result']['header']['timestamp']
-            Node_Get_LastBlocknumberDetails.labels(NodeIP=NodeIP, NodePort=NodePort, LastBlocknumber=Blocknumber,LastBlocknumberInt=int(Blocknumber,16), LastBlocknumberHash=LastBlocknumberHash).set(LastBlocknumberTimestamp)
+            Node_Get_LastBlocknumberDetails.labels(NodeIP=NodeIP, NodePort=NodePort, LastBlocknumber=Blocknumber,LastBlocknumberInt=int(Blocknumber,16), LastBlocknumberHash=LastBlocknumberHash, NodeID=node_id).set(LastBlocknumberTimestamp)
         Node_Get_NodePeers_by_peerCount = GetResult.peerCount()
         if Node_Get_NodePeers_by_peerCount != -99:
             NodePeers = Node_Get_NodePeers_by_peerCount['result']

--- a/CITA_Monitor_Server_Docker/config/dashboards/CitaAgentExporterDashboard.json
+++ b/CITA_Monitor_Server_Docker/config/dashboards/CitaAgentExporterDashboard.json
@@ -12,11 +12,12 @@
       }
     ]
   },
-  "description": "CitaAgent Exporter 监控展示面板",
+  "description": "CitaAgent Exporter Dashboard",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1553051068518,
+  "id": 6,
+  "iteration": 1553670710684,
   "links": [
     {
       "icon": "external link",
@@ -426,7 +427,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
+        "w": 4,
         "x": 0,
         "y": 16
       },
@@ -508,7 +509,7 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 8,
+        "x": 4,
         "y": 16
       },
       "id": 6,
@@ -588,8 +589,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 16
       },
       "id": 10,
@@ -647,6 +648,191 @@
         }
       ],
       "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "id": 19,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "$node_id",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Node ID",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 21,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "Node_Get_DirInfo_DirNumber{NodeDir=\"/github/cita_secp256k1_sha3/monitor_chain_02/0\"}",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "目录文件夹数量",
+          "refId": "C"
+        },
+        {
+          "expr": "Node_Get_DirInfo_FilesNumber{NodeDir=\"/github/cita_secp256k1_sha3/monitor_chain_02/0\"}",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "目录文件数量",
+          "refId": "B"
+        },
+        {
+          "expr": "Node_Get_DirInfo_TotalFileSize{NodeDir=\"/github/cita_secp256k1_sha3/monitor_chain_02/0\"}",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "目录使用总量",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "目录 [ $node_dir ]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 5,
+          "format": "decbytes",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "5s",
@@ -886,8 +1072,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "0x006dd6f93e9f06d8be1b533f686fc80d233a0a6c9787d27d7efa2b85fc4e40c1",
-          "value": "0x006dd6f93e9f06d8be1b533f686fc80d233a0a6c9787d27d7efa2b85fc4e40c1"
+          "text": "0xb84a2dfb80fbd85ec1915d396a939861440a66ef8f154cc97c0b207b3f915351",
+          "value": "0xb84a2dfb80fbd85ec1915d396a939861440a66ef8f154cc97c0b207b3f915351"
         },
         "datasource": "Prometheus",
         "definition": "label_values(Node_Get_LastBlocknumberDetails,LastBlocknumberHash) ",
@@ -898,6 +1084,56 @@
         "name": "LastBlocknumberHash",
         "options": [],
         "query": "label_values(Node_Get_LastBlocknumberDetails,LastBlocknumberHash) ",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "0",
+          "value": "0"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(Node_Get_LastBlocknumber,NodeID) ",
+        "hide": 2,
+        "includeAll": false,
+        "label": "NodeID",
+        "multi": false,
+        "name": "node_id",
+        "options": [],
+        "query": "label_values(Node_Get_LastBlocknumber,NodeID) ",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "/github/cita_secp256k1_sha3/monitor_chain_02/0",
+          "value": "/github/cita_secp256k1_sha3/monitor_chain_02/0"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(Node_Get_DirInfo_TotalFileSize{instance=~'$node:$port'},NodeDir) ",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Node Dir",
+        "multi": false,
+        "name": "node_dir",
+        "options": [],
+        "query": "label_values(Node_Get_DirInfo_TotalFileSize{instance=~'$node:$port'},NodeDir) ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -940,7 +1176,7 @@
     ]
   },
   "timezone": "",
-  "title": "CitaAgent Exporter 监控展示面板",
-  "uid": "VXdVrO3iz",
-  "version": 1
+  "title": "CitaAgent Exporter Dashboard",
+  "uid": "VXdVrO3iz1",
+  "version": 2
 }

--- a/CITA_Monitor_Server_Docker/config/dashboards/HostExporter.json
+++ b/CITA_Monitor_Server_Docker/config/dashboards/HostExporter.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Node Exporter 监控展示看板",
+  "description": "Host Exporter 监控展示看板",
   "editable": true,
   "gnetId": 8919,
   "graphTooltip": 0,
@@ -1809,7 +1809,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Node Exporter 监控展示看板",
+  "title": "Host Exporter 监控展示看板",
   "uid": "9CWBz0bik",
   "version": 1
 }

--- a/CITA_Monitor_Server_Docker/config/dashboards/NodeExporterDashboard.json
+++ b/CITA_Monitor_Server_Docker/config/dashboards/NodeExporterDashboard.json
@@ -12,11 +12,11 @@
       }
     ]
   },
-  "description": "Host Exporter 监控展示看板",
+  "description": "Node Exporter Dashboard",
   "editable": true,
   "gnetId": 8919,
   "graphTooltip": 0,
-  "iteration": 1553051095310,
+  "iteration": 1553670115554,
   "links": [
     {
       "asDropdown": false,
@@ -50,8 +50,8 @@
       "scopedVars": {
         "node": {
           "selected": true,
-          "text": "192.168.2.123",
-          "value": "192.168.2.123"
+          "text": "192.168.2.174",
+          "value": "192.168.2.174"
         }
       },
       "style": {},
@@ -294,7 +294,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 - (avg(irate(node_cpu_seconds_total{instance=~\"$node:$port\",mode=\"idle\"}[5m])) * 100)",
+          "expr": "100 - (avg(irate(node_cpu_seconds_total{instance=~\"$node:$port\",mode=\"idle\"}[1m])) * 100)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -305,7 +305,7 @@
         }
       ],
       "thresholds": "50,80",
-      "title": "CPU使用率（5m）",
+      "title": "CPU使用率",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1396,39 +1396,47 @@
       }
     },
     {
-      "aliasColors": {},
+      "aliasColors": {
+        "内存_Avaliable": "#6ED0E0",
+        "内存_Cached": "#EF843C",
+        "内存_Free": "#629E51",
+        "内存_Total": "#6d1f62",
+        "内存_Used": "#eab839",
+        "可用": "#9ac48a",
+        "总内存": "#bf1b00"
+      },
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 0,
+      "decimals": 2,
+      "fill": 3,
       "gridPos": {
         "h": 11,
         "w": 12,
         "x": 0,
         "y": 20
       },
-      "id": 169,
+      "height": "300",
+      "id": 173,
       "legend": {
-        "alignAsTable": true,
-        "avg": true,
+        "alignAsTable": false,
+        "avg": false,
         "current": true,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": true,
+        "max": false,
         "min": false,
-        "rightSide": true,
+        "rightSide": false,
         "show": true,
         "total": false,
         "values": true
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 3,
       "links": [],
-      "nullPointMode": "null as zero",
+      "nullPointMode": "null",
       "percentage": false,
-      "pointradius": 0.5,
-      "points": false,
+      "pointradius": 5,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -1436,18 +1444,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node_hwmon_temp_celsius{instance=\"$node:$port\"}",
+          "expr": "100 - (avg(irate(node_cpu_seconds_total{instance=~\"$node:$port\",mode=\"idle\"}[1m])) * 100)",
           "format": "time_series",
+          "hide": false,
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{chip}} {{sensor}}",
-          "refId": "A"
+          "legendFormat": "CPU 使用率/每分钟",
+          "refId": "A",
+          "step": 4
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "硬件温度",
+      "title": "CPU使用率",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1463,16 +1474,16 @@
       },
       "yaxes": [
         {
-          "format": "celsius",
-          "label": null,
+          "format": "percent",
+          "label": "cpu use percent / min",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
+          "label": "",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -1638,7 +1649,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -1676,8 +1687,8 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {
-          "text": "node_exporter_01",
-          "value": "node_exporter_01"
+          "text": "EP_Host_192_168_2_174",
+          "value": "EP_Host_192_168_2_174"
         },
         "datasource": "Prometheus",
         "definition": "label_values(node_uname_info{job=~'$job'},nodename)",
@@ -1703,14 +1714,14 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {
-          "text": "192.168.2.123",
-          "value": "192.168.2.123"
+          "text": "192.168.2.174",
+          "value": "192.168.2.174"
         },
         "datasource": "Prometheus",
         "definition": "label_values(node_uname_info{nodename='$name'},instance)",
         "hide": 0,
         "includeAll": false,
-        "label": "节点",
+        "label": "主机",
         "multi": false,
         "multiFormat": "regex values",
         "name": "node",
@@ -1809,7 +1820,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Host Exporter 监控展示看板",
+  "title": "Node Exporter Dashboard",
   "uid": "9CWBz0bik",
   "version": 1
 }

--- a/CITA_Monitor_Server_Docker/config/dashboards/ProcessExporterDashboard.json
+++ b/CITA_Monitor_Server_Docker/config/dashboards/ProcessExporterDashboard.json
@@ -12,11 +12,11 @@
       }
     ]
   },
-  "description": "Process Exporter 监控展示看板",
+  "description": "Process Exporter Dashboard",
   "editable": true,
   "gnetId": 249,
   "graphTooltip": 1,
-  "iteration": 1553051117827,
+  "iteration": 1553671701679,
   "links": [
     {
       "asDropdown": false,
@@ -673,8 +673,9 @@
       {
         "allValue": null,
         "current": {
-          "text": "192.168.2.123",
-          "value": "192.168.2.123"
+          "tags": [],
+          "text": "192.168.2.174",
+          "value": "192.168.2.174"
         },
         "datasource": "Prometheus",
         "definition": "label_values(up{job=~'process_exporter'},instance)",
@@ -698,7 +699,6 @@
       {
         "allValue": ".+",
         "current": {
-          "tags": [],
           "text": "All",
           "value": "$__all"
         },
@@ -753,7 +753,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Process Exporter 监控展示看板",
+  "title": "Process Exporter Dashboard",
   "uid": "eKkL1dqiz",
   "version": 1
 }

--- a/CITA_Monitor_Server_Docker/config/dashboards/RabbitMQExporterDashboard.json
+++ b/CITA_Monitor_Server_Docker/config/dashboards/RabbitMQExporterDashboard.json
@@ -12,11 +12,11 @@
       }
     ]
   },
-  "description": "RabbitMQ Exporter 监控展示看板",
+  "description": "RabbitMQ Exporter Dashboard",
   "editable": true,
   "gnetId": 2121,
   "graphTooltip": 0,
-  "iteration": 1553051181056,
+  "iteration": 1553671759145,
   "links": [
     {
       "icon": "external link",
@@ -1230,8 +1230,9 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "192.168.2.123",
-          "value": "192.168.2.123"
+          "tags": [],
+          "text": "192.168.2.174",
+          "value": "192.168.2.174"
         },
         "datasource": "Prometheus",
         "definition": "label_values(up{job=~'rabbitmq_exporter'},instance)",
@@ -1284,7 +1285,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "RabbitMQ Exporter 监控展示看板",
+  "title": "RabbitMQ Exporter Dashboard",
   "uid": "JJ0tJOqmz",
   "version": 1
 }

--- a/CITA_Monitor_Server_Docker/config/dashboards/SumExporterDashboard.json
+++ b/CITA_Monitor_Server_Docker/config/dashboards/SumExporterDashboard.json
@@ -12,11 +12,11 @@
       }
     ]
   },
-  "description": "Sum Exporter 监控展示面板",
+  "description": "Sum Exporter Dashboard",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1553049945722,
+  "iteration": 1553669833515,
   "links": [],
   "panels": [
     {
@@ -70,11 +70,11 @@
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 11,
@@ -93,17 +93,17 @@
         "total": false,
         "values": true
       },
-      "lines": false,
+      "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
-      "points": false,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -321,6 +321,27 @@
           "thresholds": [],
           "type": "number",
           "unit": "short"
+        },
+        {
+          "alias": "Chain node id",
+          "colorMode": "value",
+          "colors": [
+            "#890f02",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "",
+          "linkUrl": "",
+          "mappingType": 1,
+          "pattern": "NodeID",
+          "thresholds": [
+            ""
+          ],
+          "type": "number",
+          "unit": "short"
         }
       ],
       "targets": [
@@ -342,7 +363,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
@@ -371,7 +392,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -462,7 +483,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "0xc45c6d819213b6725925f86f5e78a68036036efbdcd43aa6b2fb90c8791c660e",
           "value": "0xc45c6d819213b6725925f86f5e78a68036036efbdcd43aa6b2fb90c8791c660e"
         },
@@ -470,7 +490,7 @@
         "definition": "label_values(Node_Get_LastBlocknumber,FirstBlocknumberHash)",
         "hide": 0,
         "includeAll": false,
-        "label": "链",
+        "label": "Chain(创世块 Hash)",
         "multi": false,
         "name": "Chain",
         "options": [],
@@ -517,7 +537,7 @@
     ]
   },
   "timezone": "",
-  "title": "Sum Exporter 监控展示面板",
+  "title": "Sum Exporter Dashboard",
   "uid": "dLEMP5qik",
   "version": 1
 }


### PR DESCRIPTION
# 修改
* 修改 python 脚本，添加了目录统计函数，获取目录下的文件数量和目录总大小
* 因为脚本变更，添加了接收目录的变量，重构镜像并上传更新
* docker-compose 文件修改，支持 .env 下的 node_dir 变量传入，直接填写需要分析的目录在宿主机的绝对路径

# 数据获取如下
```
# HELP Node_Get_DirInfo_TotalFileSize Get TotalFileSize by Node Dir;
# TYPE Node_Get_DirInfo_TotalFileSize gauge
Node_Get_DirInfo_TotalFileSize{NodeDir="/github/cita_secp256k1_sha3/monitor_chain_02/0",NodeIP="192.168.2.174",NodePort="1337"} 2.78779908e+08
# HELP Node_Get_DirInfo_FilesNumber Get FilesNumber by Node Dir;
# TYPE Node_Get_DirInfo_FilesNumber gauge
Node_Get_DirInfo_FilesNumber{NodeDir="/github/cita_secp256k1_sha3/monitor_chain_02/0",NodeIP="192.168.2.174",NodePort="1337"} 68.0
# HELP Node_Get_DirInfo_DirNumber Get DirNumber by Node Dir;
# TYPE Node_Get_DirInfo_DirNumber gauge
Node_Get_DirInfo_DirNumber{NodeDir="/github/cita_secp256k1_sha3/monitor_chain_02/0",NodeIP="192.168.2.174",NodePort="1337"} 7.0
```