### PR TITLE
Fix #87: disk use percent pie graph

### DIFF
--- a/agent/cita_monitor_agent.py
+++ b/agent/cita_monitor_agent.py
@@ -69,8 +69,11 @@ Get current block time and previous block time, label include CurrentHeight, Pre
 NODE_DIR_TOTAL_SIZE_TITLE = "[ value is size ] \
 Get the node directory total size."
 
-SYSTEM_DISK_USAGE_TITLE = "[ value is size ] \
-Get the system Hard disk Usage."
+NODE_DISK_USED_SIZE_TITLE = "[ value is size ] \
+Get the disk used size."
+
+NODE_DISK_FREE_SIZE_TITLE = "[ value is size ] \
+Get the disk free size."
 
 BLOCK_INTERVAL_TITLE = "[ value is interval ] \
 Get current block time and previous block time."
@@ -223,10 +226,14 @@ def exporter():
                            NODE_DIR_TOTAL_SIZE_TITLE,
                            ["NodeIP", "NodePort", "NodeDir"],
                            registry=registry)
-    system_disk_usage = Gauge("Get_System_Disk_Usage",
-                              SYSTEM_DISK_USAGE_TITLE,
-                              ["NodeIP", "NodePort", "DiskTotal", "DiskUsed", "DiskFree"],
-                              registry=registry)
+    disk_used_size = Gauge("Node_Get_DiskInfo_UsedSize",
+                           NODE_DISK_USED_SIZE_TITLE,
+                           ["NodeIP", "NodePort", "NodeDir"],
+                           registry=registry)
+    disk_free_size = Gauge("Node_Get_DiskInfo_FreeSize",
+                           NODE_DISK_FREE_SIZE_TITLE,
+                           ["NodeIP", "NodePort", "NodeDir"],
+                           registry=registry)
     block_interval = Gauge("Node_Get_BlockTimeDifference",
                            BLOCK_INTERVAL_TITLE, ["NodeIP", "NodePort"],
                            registry=registry)
@@ -269,11 +276,12 @@ def exporter():
         dir_total_size.labels(NodeIP=node_ip,
                               NodePort=node_port,
                               NodeDir=path,).set(FILE_TOTAL_SIZE)
-    system_disk_usage.labels(NodeIP=node_ip,
-                             NodePort=node_port,
-                             DiskTotal=DISK_TOTAL,
-                             DiskUsed=DISK_USED,
-                             DiskFree=DISK_FREE)
+    disk_used_size.labels(NodeIP=node_ip,
+                          NodePort=node_port,
+                          NodeDir=path,).set(DISK_USED)
+    disk_free_size.labels(NodeIP=node_ip,
+                          NodePort=node_port,
+                          NodeDir=path,).set(DISK_FREE)
 
     first_block_info = class_result.block_number_detail('0x0')
     if 'result' in first_block_info:

--- a/agent/cita_monitor_agent.py
+++ b/agent/cita_monitor_agent.py
@@ -263,25 +263,22 @@ def exporter():
 
     service_status.labels(NodeIP=node_ip, NodePort=node_port).set(1)
     class_result = ExporterFunctions(node_ip, node_port)
-    if ',' in NODE_FILE_PATH:
-        path_list = NODE_FILE_PATH.split(',')
-        for path in path_list:
-            dir_analysis(path)
-            dir_total_size.labels(NodeIP=node_ip,
-                                  NodePort=node_port,
-                                  NodeDir=path).set(FILE_TOTAL_SIZE)
-    else:
-        path = NODE_FILE_PATH
-        dir_analysis(path)
-        dir_total_size.labels(NodeIP=node_ip,
-                              NodePort=node_port,
-                              NodeDir=path,).set(FILE_TOTAL_SIZE)
-    disk_used_size.labels(NodeIP=node_ip,
-                          NodePort=node_port,
-                          NodeDir=path,).set(DISK_USED)
-    disk_free_size.labels(NodeIP=node_ip,
-                          NodePort=node_port,
-                          NodeDir=path,).set(DISK_FREE)
+    dir_analysis(NODE_FILE_PATH)
+    dir_total_size.labels(
+        NodeIP=node_ip,
+        NodePort=node_port,
+        NodeDir=NODE_FILE_PATH,
+    ).set(FILE_TOTAL_SIZE)
+    disk_used_size.labels(
+        NodeIP=node_ip,
+        NodePort=node_port,
+        NodeDir=NODE_FILE_PATH,
+    ).set(DISK_USED)
+    disk_free_size.labels(
+        NodeIP=node_ip,
+        NodePort=node_port,
+        NodeDir=NODE_FILE_PATH,
+    ).set(DISK_FREE)
 
     first_block_info = class_result.block_number_detail('0x0')
     if 'result' in first_block_info:

--- a/server/grafana/dashboards/CITANodeInfoDashboard.json
+++ b/server/grafana/dashboards/CITANodeInfoDashboard.json
@@ -1805,23 +1805,33 @@
       "strokeWidth": "1",
       "targets": [
         {
-          "expr": "(Node_Get_DirInfo_TotalFileSize{job=\"$job\",instance=\"$node:$port\"} * 1024)",
+          "expr": "Node_Get_DirInfo_TotalFileSize{job=\"$job\",instance=\"$node:$port\"} * 1024",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "use",
+          "legendFormat": "Node Dir Size Used by [ node : $node_id ]",
           "refId": "A"
         },
         {
-          "expr": "$NodeDisk",
+          "expr": "Node_Get_DiskInfo_UsedSize{job=\"$job\",instance=\"$node:$port\"} - (Node_Get_DirInfo_TotalFileSize{job=\"$job\",instance=\"$node:$port\"} * 1024)",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "total",
+          "legendFormat": "Other Used",
           "refId": "B"
+        },
+        {
+          "expr": "Node_Get_DiskInfo_FreeSize{job=\"$job\",instance=\"$node:$port\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Available",
+          "refId": "C"
         }
       ],
       "title": "Disk Usage",
@@ -1880,7 +1890,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Node Dir Size",
+      "title": "Node Dir Size Used",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2639,32 +2649,6 @@
         "name": "NodePort",
         "options": [],
         "query": "label_values(Node_Get_LastBlockNumber{instance=~'$node:$port'},NodePort) ",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "isNone": true,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": "Prometheus",
-        "definition": "label_values(Node_Get_DirInfo_TotalFileSize{instance=~'$node:$port'},NodeDisk) ",
-        "hide": 2,
-        "includeAll": false,
-        "label": "NodeDisk",
-        "multi": false,
-        "name": "NodeDisk",
-        "options": [],
-        "query": "label_values(Node_Get_DirInfo_TotalFileSize{instance=~'$node:$port'},NodeDisk) ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
* script 添加关于 disk used 和 disk free 的变量以及标签
* script 删除 disk total 变量并修改了 node dir 的变量名称
* graph 添加 disk used 和 disk free 查询
* graph 删除无用的 dashboard 变量 NodeDisk
* del 多个路径输入的判断（因为无实际使用意义）

![image](https://user-images.githubusercontent.com/35131072/57995324-0837e300-7af4-11e9-8f6e-a056c56968f9.png)
