### PR TITLE
add `make generate-build-version` and add `show-full-version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+tmp/
+cita-test-chain/
+server/grafana_data/
+server/prometheus_data/
+.vscode/
+.build-version

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL = /bin/sh
 # receipts for Testing
 .PHONY: test test-unit test-intergration
 # receipts for Release
-.PHONY: changelog changelog-check
+.PHONY: changelog changelog-check generate-build-version show-full-version
 
 .SILENT: help
 
@@ -134,6 +134,18 @@ bump-version-file: ## Update version number in VERSION file.
 		new_version=`cat VERSION` ;\
 		echo "New version: $${new_version}" ;\
 	fi
+
+generate-build-version: ## Generate build version using format "yyyymmddHHMMSS.commitshortid", e.g.: "20190606201137.40564fe".
+	@# build version are only ASCII alphanumerics and hyphen [0-9A-Za-z-] alllowed
+	@commitid=$(shell git rev-parse --short HEAD); \
+	builddate=$(shell date +"%Y%m%d%H%M%S");  \
+	printf "%s.%s" $$builddate $$commitid > .build-version
+	@cat .build-version
+
+show-full-version: ## Show product version and build version, e.g.: "v0.3.0+20190606201137.40564fe".
+	@product_version=$(shell cat VERSION); \
+	build_version=$(shell cat .build-version);  \
+	printf "v%s+%s" $$product_version $$build_version
 
 send-pull-request: ## Send a Pull Request with current git branch
 	@repo_url=`git ls-remote --get-url` ;\


### PR DESCRIPTION
- add `make generate-build-version`: Generate build metadata using format "x.y.z+yyyymmddHHMMSS.commitshortid", e.g.: "0.3.0+20190606200449.40564fe"; 
- add `make show-full-version`: Show product version and build version, e.g.: "v0.3.0+20190606201137.40564fe"


@blankwu 先执行 `make generate-build-version` 得到 build version，然后执行 `make show-full-version` 可以显示完整的版本号，把这个结果用于显示在面板中