### PR TITLE
resolve #105: add test dir and init system testing env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ server/grafana_data/
 server/prometheus_data/
 .vscode/
 .build-version
+test/dummy/*

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,0 @@
-dummy/test-chain
-cita-bin

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+dummy/test-chain
+cita-bin

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,5 @@
+get-block-number:
+	curl -sS  -X POST --data '{"jsonrpc":"2.0","method":"blockNumber","params":[],"id":1}' 127.0.0.1:1337
+
+watch-block-number:
+	watch -n 1 -c "make get-block-number"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,109 @@
-get-block-number:
-	curl -sS  -X POST --data '{"jsonrpc":"2.0","method":"blockNumber","params":[],"id":1}' 127.0.0.1:1337
+.DEFAULT_GOAL:=help
+SHELL = /bin/sh
 
-watch-block-number:
-	watch -n 1 -c "make get-block-number"
+# main receipts
+.PHONY: deps build clean help
+# receipts for Code Quality
+.PHONY: code-quality lint-shell-code format-shell-code
+# receipts for Testing
+.PHONY: test test-unit test-intergration
+
+.SILENT: help
+
+# DEFINE GLOBAL VARIABLES
+RPC_CALL_COUNT=0 # counter for cita_rpc, so that each "id" in RPC request params is unqiue 
+
+# DEFINE FUNCTIONS
+
+# usage: $(call cita_rpc,method,params)
+# e.g.: $(call cita_rpc,getMetaData,["latest"])
+# e.g.: $(call cita_rpc,blockNumber,[])
+define cita_rpc
+	$(eval RPC_CALL_COUNT=$(shell echo $$(($(RPC_CALL_COUNT)+1)))) # inc counter
+	@#echo "RPC_CALL_COUNT: $(RPC_CALL_COUNT)"
+	curl -sS  -X POST --data '{"jsonrpc":"2.0","method":"$(1)","params":$(2),"id":$(RPC_CALL_COUNT)}' 127.0.0.1:1337 | jq '.'
+endef
+
+# DEFINE RECEIPES
+
+
+##@ Dependencies
+
+deps: ## Download the depenedencies.
+	$(info Checking and getting dependencies)
+	@jq --version || brew install jq || apt-get install jq || (echo "install jq: https://stedolan.github.io/jq/download/" && exit 1)
+
+##@ Cleanup
+clean: ## Clean up.
+	$(info Cleaning up things, remove all containers/network:)
+	docker-compose down
+
+##@ Building
+
+build: clean deps ## Building the base docker image, e.g.: $ make build CITA_VERSION=0.24.0.
+	$(info Building the base docker image)
+	docker-compose build --build-arg CITA_VERSION=$${CITA_VERSION:=0.24.0} cita_node
+	@echo "Run [make check-cita-bin-version] to check bin version"
+	@echo "Or run [make run-cita-node-bash] to login the container"
+
+run-cita-node-bash: ## Login a cita_node container and mount dummy dir to /data, useful for debugging CITA node runtime enviroment.
+	docker-compose run --rm -v $${PWD}/dummy:/data/ cita_node bash
+
+check-cita-bin-version: ## Check CITA bin version in the base image.
+	docker-compose run --rm cita_node bash -c "bin/cita-jsonrpc --version | head -n2"
+
+check-cita-bin-version-all: ## Check CITA all bin version in the base image.
+	@cmd="find bin -name cita-* -exec grep -IL . '{}' \; | xargs -I @ sh -c 'echo @ ; @ --version | head -n2; echo'" ;\
+		docker-compose run --rm cita_node bash -c "$${cmd}"
+
+config-node: ## Create 1 node config and save to dummy/test-chain.
+	docker-compose run --rm -e NODES_CONFIG=$${NODES_CONFIG:=node0:4000} config
+	@echo "node config saved at:"
+	@ls -d1 dummy/test-chain
+	@echo "1. start: $$ make start-node"
+	@echo "2. check metaData: $$ make rpc-get-meta-data"
+	@echo "3. check blockNumber: $$ make rpc-block-number or $$ make watch target=rpc-block-number"
+
+config-nodes: ## Create 4 nodes config and save to dummy/test-chain, custom nodes e.g.: $ make config-nodes NODES_CONFIG=node0:4000,node1:4000,node2:4000,node3:4000
+	docker-compose run --rm -e NODES_CONFIG=$${NODES_CONFIG:=node0:4000,node1:4000,node2:4000,node3:4000} config
+
+start-node: ## Start node0.
+	docker-compose up node0
+
+start-nodes: ## Start nodes, start all by default, to start specified nodes e.g.: $ make start-nodes NODES="node0 node3"
+	docker-compose up $${NODES:=node0 node1 node2 node3}
+
+stop-nodes: ## Stop nodes, stop all by default, to stop specified nodes e.g.: $ make start-nodes NODES="node3"
+	docker-compose stop $${NODES:=}
+
+rpc-get-meta-data: ## Call CITA RPC method getMetaData.
+	$(call cita_rpc,getMetaData,["latest"])
+
+rpc-block-number: ## Call CITA RPC method blockNumber.
+	$(call cita_rpc,blockNumber,[])
+
+
+##@ Testing
+
+test: ## Run the unit and intergration testsuites.
+test: test-unit test-intergration
+
+test-unit: ## Run the unit testsuite.
+	$(info Run the unit testsuite)
+
+test-intergration: ## Run the intergration testsuite.
+	$(info Run the intergration testsuite)
+
+
+##@ Helpers
+# helpers are independent recipes, should be able to used in different projects
+
+watch: ## Watch a target, e.g.: $ make watch TARGET=test-block-number
+	@if [ "$${TARGET}" == "" ]; then \
+		echo "watch which target? .e.g.: make watch TARGET=test-block-number" ;\
+	else \
+		watch -n 1 -c "make $${TARGET}" ;\
+	fi
+
+help:  ## Display help message.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,27 @@
+# Testing
+
+## How to start a local CITA nodes network?
+
+### First of all, prepare cita-node docker image
+
+build base image for cita-node: `$ make build CITA_VERSION=0.24.0`
+
+### To start 1 node
+
+1. generate node config: `$ make config-node`
+2. start 1 node: `$ make start-node`
+3. query block number: `$ make rpc-block-number`
+
+### To start 4 nodes
+
+1. generate nodes config: `$ make config-nodes`
+2. start 4 node: `$ make start-nodes`
+3. query block number: `$ make rpc-block-number`
+
+### To start any number of node
+
+1. generate nodes config: `$ make config-nodes NODES_CONFIG=node0:4000,node1:4000,node2:4000,node3:4000,node4:4000`
+2. start 5 nodes: `$ make start-nodes NODES="node0 node1 node2 node3 node4"`
+3. watch block number: `$ make watch TARGET=rpc-block-number`
+4. stop 1 node: `$ make stop-nodes NODES="node3"`
+5. watch step 3, block number should be still growing

--- a/test/cita-node/Dockerfile
+++ b/test/cita-node/Dockerfile
@@ -1,0 +1,70 @@
+# IMPORTANT: the order of each directive is important, it will effect image cache
+
+FROM cita/cita-run:ubuntu-18.04-20180813
+
+# Build packages are system packages that are only required for installing
+# gems, precompiling assets, etc. They are not included in the final Docker
+# image.
+# ENV BUILD_PACKAGES \
+#     # Required for the sqlite3 gem to compile.
+#     sqlite-dev
+
+# Runtime packages are system packages that are required for the application
+# to run. They are included in the final Docker image.
+# ENV RUNTIME_PACKAGES \
+#     # Required for the sqlite3 gem.
+#     sqlite-libs git
+
+# Put everything in its own directory.
+WORKDIR /opt/cita-run
+ENV APP_HOME /opt/cita-run
+
+# # Build your application.
+# RUN \
+#     # Upgrade old packages.
+#     # apk --update upgrade && \
+#     # Ensure we have ca-certs installed.
+#     apk add --no-cache ca-certificates && \
+#     # Install build packages.
+#     apk add --virtual build-packages build-base $BUILD_PACKAGES && \
+#     # Install runtime packages.
+#     apk add --virtual runtime-packages nodejs tzdata $RUNTIME_PACKAGES
+
+
+# Pass CITA_VERSION
+ARG CITA_VERSION="0.20.2"
+ENV CITA_VERSION $CITA_VERSION
+ENV CITA_DOWNLOAD_URL=https://github.com/cryptape/cita/releases/download/v${CITA_VERSION}/cita_secp256k1_sha3.tar.gz
+
+# ADD ${CITA_DOWNLOAD_URL} cita_secp256k1_sha3.tar.gz
+# RUN tar zxf cita_secp256k1_sha3.tar.gz
+
+# FIXME: `ADD` won't use cache in this case
+RUN curl -L -O -# ${CITA_DOWNLOAD_URL} && tar zxf cita_secp256k1_sha3.tar.gz
+RUN rm cita_secp256k1_sha3.tar.gz
+
+# # Clean up build packages.
+# RUN \
+#     apk del --purge build-packages && \
+#     # Delete APK and gem caches.
+#     find / -type f -iname \*.apk-new -delete && \
+#     rm -rf /var/cache/apk/* && \
+#     rm -rf /usr/local/lib/ruby/gems/*/cache/* && \
+#     rm -rf ~/.gem
+
+
+# Alpine Linux's Ash shell will automatically source the /etc/profile script each time the shell is launched
+ENV ENV="/etc/profile"
+COPY cita-node/docker-init /usr/sbin/
+RUN echo source /usr/sbin/docker-init >> /etc/profile
+
+ARG CITA_NODE_ID=""
+ENV CITA_NODE_ID $CITA_NODE_ID
+
+# auto setup and start CITA service with config "test-chain/$CITA_NODE_ID"
+# CMD bash -c 'cd cita_secp256k1_sha3 && if [ -d test-chain ]; then bin/cita setup test-chain/$CITA_NODE_ID; bin/cita start test-chain/$CITA_NODE_ID; bin/cita logs test-chain/$CITA_NODE_ID chain; fi;'
+
+ENV WORKDIR /opt/cita-run/cita_secp256k1_sha3
+WORKDIR ${WORKDIR}
+ENV PATH "$PATH:$WORKDIR/bin:$WORKDIR/scripts"
+CMD bash -c 'if [ -d /data/test-chain/$CITA_NODE_ID ]; then cd /data/; cita setup test-chain/$CITA_NODE_ID; cita start test-chain/$CITA_NODE_ID; cita logs test-chain/$CITA_NODE_ID chain; fi;'

--- a/test/cita-node/Dockerfile
+++ b/test/cita-node/Dockerfile
@@ -1,6 +1,6 @@
 # IMPORTANT: the order of each directive is important, it will effect image cache
 
-FROM cita/cita-run:ubuntu-18.04-20180813
+FROM cita/cita-run:ubuntu-18.04-20190419
 
 # Build packages are system packages that are only required for installing
 # gems, precompiling assets, etc. They are not included in the final Docker
@@ -32,7 +32,7 @@ ENV APP_HOME /opt/cita-run
 
 
 # Pass CITA_VERSION
-ARG CITA_VERSION="0.20.2"
+ARG CITA_VERSION=""
 ENV CITA_VERSION $CITA_VERSION
 ENV CITA_DOWNLOAD_URL=https://github.com/cryptape/cita/releases/download/v${CITA_VERSION}/cita_secp256k1_sha3.tar.gz
 
@@ -61,10 +61,13 @@ RUN echo source /usr/sbin/docker-init >> /etc/profile
 ARG CITA_NODE_ID=""
 ENV CITA_NODE_ID $CITA_NODE_ID
 
-# auto setup and start CITA service with config "test-chain/$CITA_NODE_ID"
-# CMD bash -c 'cd cita_secp256k1_sha3 && if [ -d test-chain ]; then bin/cita setup test-chain/$CITA_NODE_ID; bin/cita start test-chain/$CITA_NODE_ID; bin/cita logs test-chain/$CITA_NODE_ID chain; fi;'
-
 ENV WORKDIR /opt/cita-run/cita_secp256k1_sha3
 WORKDIR ${WORKDIR}
 ENV PATH "$PATH:$WORKDIR/bin:$WORKDIR/scripts"
-CMD bash -c 'if [ -d /data/test-chain/$CITA_NODE_ID ]; then cd /data/; cita setup test-chain/$CITA_NODE_ID; cita start test-chain/$CITA_NODE_ID; cita logs test-chain/$CITA_NODE_ID chain; fi;'
+
+# bugfix NODE_PATH in bin/cita script for CITA v0.24.0
+# ref: https://github.com/cryptape/cita/issues/626
+RUN sed -i 's/NODE_PATH=/NODE_PATH="$(realpath ${NODE_NAME})" # was: /' ${WORKDIR}/bin/cita
+
+# auto setup and start CITA service with config "test-chain/$CITA_NODE_ID"
+CMD bash -c 'if [ -d /data/test-chain/$CITA_NODE_ID ]; then cd /data/; cita bebop setup test-chain/$CITA_NODE_ID; cita bebop start test-chain/$CITA_NODE_ID; cita bebop logs test-chain/$CITA_NODE_ID chain; fi;'

--- a/test/cita-node/docker-init
+++ b/test/cita-node/docker-init
@@ -1,0 +1,2 @@
+# common-used alias
+alias ll='ls -lah'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 # Usage:
-# 1. build base image for cita-node: $ docker-compose -e CITA_VERSION=0.20.2 build cita_node
+# 1. build base image for cita-node: $ docker-compose build --build-arg CITA_VERSION=0.24.0 cita_node
 # 2. generate node config: $ docker-compose run -e NODES_CONFIG=node0:4000 config
 # 3. start 1 node: $ docker-compose up node0
 # 4. start 4 nodes: $ docker-compose up node0 node1 node2 node3
@@ -16,7 +16,7 @@ services:
   # run cita command: $ docker-compose run cita_node cita help
   # login container: $ docker-compose run cita_node bash
   # check CITA bin version: $ docker-compose run cita_node bash -c "bin/cita-jsonrpc --version | head -n2"
-  # check CITA all bin version: $ docker-compose run cita_node bash -c "find bin -type f -executable -name cita-*  | xargs -I @ sh -c 'echo @ ; @ --version | head -n2; echo' "
+  # check CITA all bin version: $ docker-compose run cita_node bash -c "find bin -name cita-* -exec grep -IL . '{}' \; | xargs -I @ sh -c 'echo @ ; @ --version | head -n2; echo'"
   cita_node:
     environment:
       - USER_ID

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,127 @@
+# Usage:
+# 1. build base image for cita-node: $ docker-compose -e CITA_VERSION=0.20.2 build cita_node
+# 2. generate node config: $ docker-compose run -e NODES_CONFIG=node0:4000 config
+# 3. start 1 node: $ docker-compose up node0
+# 4. start 4 nodes: $ docker-compose up node0 node1 node2 node3
+
+# to remove all containers/network:
+# docker-compose down
+
+version: '3.4'
+
+services:
+
+  # build base image for CITA node, usage example:
+  # build or update image: $ docker-compose build cita_node
+  # run cita command: $ docker-compose run cita_node cita help
+  # login container: $ docker-compose run cita_node bash
+  # check CITA bin version: $ docker-compose run cita_node bash -c "bin/cita-jsonrpc --version | head -n2"
+  # check CITA all bin version: $ docker-compose run cita_node bash -c "find bin -type f -executable -name cita-*  | xargs -I @ sh -c 'echo @ ; @ --version | head -n2; echo' "
+  cita_node:
+    environment:
+      - USER_ID
+      - CITA_VERSION=0.20.2 # TODO: set this in env file
+    image: cita-node
+    hostname: cita_node
+    build:
+      context: .
+      dockerfile: ./cita-node/Dockerfile
+    tty: true # enables debugging capabilities when attached to this container
+    networks:
+      cita_test_chain:
+
+  # generate CITA 4 nodes config in dummy dir/
+  # usage: $ docker-compose run config
+  # login container: $ docker-compose run config bash
+  # delete test-chain: $ rm -rf dummy/test-chain
+  config:
+    environment:
+      - USER_ID
+      - SUPER_ADMIN=0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523 # TODO: set this in env file
+      # - NODES_CONFIG=node0:4000 # setup 1 node TODO: set this in env file
+      - NODES_CONFIG=node0:4000,node1:4000,node2:4000,node3:4000 # step 4 nodes TODO: set this in env file
+    image: cita-node
+    hostname: config
+    tty: true
+    networks:
+      cita_test_chain:
+    volumes:
+      - ./dummy:/data
+    command: |
+      bash -c '
+      echo "Init nodes config in /data/test-chain";
+      if [ ! -d /data/test-chain ]; then echo "create CITA config" && create_cita_config.py create --super_admin "$${SUPER_ADMIN}" --nodes "$${NODES_CONFIG}"; mv test-chain/ /data/; fi;
+      if [ -d /data/test-chain ]; then echo "nodes config:"; ls -d1 /data/test-chain/* ; fi;
+      echo "Done config"'
+
+  # start a CITA container based on cita_node image and mount config files from dummy/test-chain/$CITA_NODE_ID
+  # start 1 node: $ docker-compose up node0
+  # login a started node container: $ docker-compose exec node0 bash
+  # start 4 nodes: $ docker-compose up node0 node1 node2 node3
+  # get meta data:
+  #   $ curl -sS  -X POST --data ' {"jsonrpc":"2.0","method":"getMetaData","params":["latest"],"id":1} ' 127.0.0.1:1337
+  # get latest block
+  #   $ curl -sS  -X POST --data ' {"jsonrpc":"2.0","method":"blockNumber","params":[],"id":1} ' 127.0.0.1:1337
+  # to stop a node: $ docker-compose stop node3
+  node0:
+    environment:
+      - USER_ID
+      - CITA_NODE_ID=0
+    image: cita-node
+    hostname: node0
+    container_name: node0
+    tty: true
+    volumes:
+      - ./dummy/test-chain/0:/data/test-chain/0
+    ports:
+      - "1337:1337"
+    networks:
+      cita_test_chain:
+
+  node1:
+    environment:
+      - USER_ID
+      - CITA_NODE_ID=1
+    image: cita-node
+    hostname: node1
+    container_name: node1
+    tty: true
+    volumes:
+      - ./dummy/test-chain/1:/data/test-chain/1
+    ports:
+      - "1338:1338"
+    networks:
+      cita_test_chain:
+
+  node2:
+    environment:
+      - USER_ID
+      - CITA_NODE_ID=2
+    image: cita-node
+    hostname: node2
+    container_name: node2
+    tty: true
+    volumes:
+      - ./dummy/test-chain/2:/data/test-chain/2
+    ports:
+      - "1339:1339"
+    networks:
+      cita_test_chain:
+
+  node3:
+    environment:
+      - USER_ID
+      - CITA_NODE_ID=3
+    image: cita-node
+    hostname: node3
+    container_name: node3
+    tty: true
+    volumes:
+      - ./dummy/test-chain/3:/data/test-chain/3
+    ports:
+      - "1340:1340"
+    networks:
+      cita_test_chain:
+
+networks:
+  cita_test_chain:

--- a/test/dummy/README.md
+++ b/test/dummy/README.md
@@ -1,0 +1,1 @@
+dummy data dir, for storing auto generated data


### PR DESCRIPTION
# Testing

## How to start a local CITA nodes network?

### First of all, prepare cita-node docker image

build base image for cita-node: `$ make build CITA_VERSION=0.24.0`

### To start 1 node

1. generate node config: `$ make config-node`
2. start 1 node: `$ make start-node`
3. query block number: `$ make rpc-block-number`

### To start 4 nodes

1. generate nodes config: `$ make config-nodes`
2. start 4 node: `$ make start-nodes`
3. query block number: `$ make rpc-block-number`

### To start any number of node

1. generate nodes config: `$ make config-nodes NODES_CONFIG=node0:4000,node1:4000,node2:4000,node3:4000,node4:4000`
2. start 5 nodes: `$ make start-nodes NODES="node0 node1 node2 node3 node4"`
3. watch block number: `$ make watch TARGET=rpc-block-number`
4. stop 1 node: `$ make stop-nodes NODES="node3"`
5. watch step 3, block number should be still growing
