### PR TITLE
resolve #111 add agent proxy to get data using one port

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,22 +1,6 @@
 # citamon_agent_cita_exporter HostName
 HOSTNAME=nodehostname
 
-# citamon_agent_host_exporter HostPort and ContainerPort
-HOST_HOSTPORT=1920
-HOST_CONTAINERPORT=9100
-
-# citamon_agent_process_exporter HostPort and ContainerPort
-PROCESS_HOSTPORT=1921
-PROCESS_CONTAINERPORT=9256
-
-# citamon_agent_rabbitmq_exporter HostPort and ContainerPort
-RABBITMQ_HOSTPORT=1922
-RABBITMQ_CONTAINERPORT=1922
-
-# citamon_agent_cita_exporter HostPort and ContainerPort
-AGENT_HOSTPORT=1923
-AGENT_CONTAINERPORT=1920
-
 # CITA node ip and port
 NODE_IP=1.1.1.1
 NODE_PORT=1337

--- a/agent/cita_exporter/Dockerfile
+++ b/agent/cita_exporter/Dockerfile
@@ -7,6 +7,6 @@ ADD . /config
 ## 安装必要的依赖包
 RUN pip3 install -r requirements.txt
 RUN mv cita-cli /bin/cita-cli && chmod +x /bin/cita-cli
-ENV PORT=1920
+ENV PORT=1923
 ## 运行命令
 CMD "python3" "cita_monitor_agent.py" "$NODE_IP_PORT" "$PORT" "$NODE_DIR"

--- a/agent/cita_monitor_agent.py
+++ b/agent/cita_monitor_agent.py
@@ -183,7 +183,7 @@ def dir_analysis(path):
 
 
 # flask object
-@NODE_FLASK.route("/metrics")
+@NODE_FLASK.route("/metrics/cita")
 def exporter():
     """Agent execution function"""
     # definition tag
@@ -437,7 +437,7 @@ def exporter():
 @NODE_FLASK.route("/")
 def index():
     """Page data view entry"""
-    index_html = "<h2>访问 /metrics 路径获取数据采集信息</h2>"
+    index_html = "<h2>访问 /metrics/cita 路径获取数据采集信息</h2>"
     return index_html
 
 

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -5,39 +5,36 @@ services:
     image: prom/node-exporter:v0.17.0
     hostname: host_exporter
     container_name: citamon_agent_host_exporter
-    ports:
-      - "${HOST_HOSTPORT}:${HOST_CONTAINERPORT}"
     volumes:
       - /proc:/host/proc
       - /sys:/host/sys
       - /:/host/rootfs
       - /etc/localtime:/etc/localtime
     command: "--path.procfs='/host/proc' --path.sysfs='/host/sys' --path.rootfs='/host/rootfs'"
+    networks:
+      - citamon-agent-net
 
   prometheus_process_exporter:
     image: ncabatoff/process-exporter:0.4.0
     hostname: process_exporter
     container_name: citamon_agent_process_exporter
-    ports:
-      - "${PROCESS_HOSTPORT}:${PROCESS_CONTAINERPORT}"
     volumes:
       - /proc:/host/proc
       - ./process_exporter_config:/config
       - /etc/localtime:/etc/localtime
     command: "--procfs /host/proc --config.path /config/process_list.yml"
+    networks:
+      - citamon-agent-net
 
   prometheus_rabbitmq_exporter:
     image: kbudde/rabbitmq-exporter:1.0.0-RC
     hostname: rabbitmq_exporter
     container_name: citamon_agent_rabbitmq_exporter
     network_mode: "host"
-    ports:
-      - "${RABBITMQ_HOSTPORT}:${RABBITMQ_CONTAINERPORT}"
     volumes:
       - /etc/localtime:/etc/localtime
     environment:
       - "RABBIT_CAPABILITIES=bert,no_sort"
-      - "PUBLISH_PORT=${RABBITMQ_CONTAINERPORT}"
 
   prometheus_cita_exporter:
     build: ./cita_exporter
@@ -45,8 +42,6 @@ services:
     hostname: ${HOSTNAME}
     container_name: citamon_agent_cita_exporter_${NODE_IP}_${NODE_PORT}
     pid: "host"
-    ports:
-      - "${AGENT_HOSTPORT}:${AGENT_CONTAINERPORT}"
     volumes:
       - ${NODE_DIR}:${NODE_DIR}:ro
       - ${SOFT_PATH}:${SOFT_PATH}:ro
@@ -55,4 +50,23 @@ services:
     environment:
       - NODE_IP_PORT=${NODE_IP}:${NODE_PORT}
       - NODE_DIR
+    networks:
+      - citamon-agent-net
 
+  prometheus_agent_proxy:
+    image: nginx:1.16.0
+    hostname: agent_proxy
+    container_name: citamon_agent_proxy
+    ports:
+      - "1920:80"
+    volumes:
+      - ./nginx.template:/etc/nginx/conf.d/nginx.template
+    environment:
+      - NGINX_HOST=${NODE_IP}
+      - NGINX_PORT=80
+    command: /bin/bash -c "envsubst < /etc/nginx/conf.d/nginx.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    networks:
+      - citamon-agent-net
+
+networks:
+  citamon-agent-net:

--- a/agent/nginx.template
+++ b/agent/nginx.template
@@ -1,0 +1,21 @@
+server {
+    listen ${NGINX_PORT};
+    server_name ${NGINX_HOST};
+            
+    location /metrics/host {
+        proxy_pass  http://prometheus_host_exporter:9100/metrics;
+    }
+            
+    location /metrics/process {
+        proxy_pass http://prometheus_process_exporter:9256/metrics;
+    }
+            
+    location /metrics/rabbitmq {
+        proxy_pass http://${NGINX_HOST}:9419/metrics;
+    }
+
+    location /metrics/cita {
+        proxy_pass http://prometheus_cita_exporter:1923/metrics/cita;
+    }
+
+}

--- a/server/config/prometheus.yml
+++ b/server/config/prometheus.yml
@@ -15,15 +15,19 @@ scrape_configs:
   - job_name: 'host_exporter'
     static_configs:
     - targets: ['host_exporter_ip:port']
+    metrics_path: "/metrics/host"
 
   - job_name: 'process_exporter'
     static_configs:
     - targets: ['process_exporter_ip:port']
+    metrics_path: "/metrics/process"
 
   - job_name: 'rabbitmq_exporter'
     static_configs:
     - targets: ['rabbitmq_exporter_ip:port']
+    metrics_path: "/metrics/rabbitmq"
 
   - job_name: 'cita_exporter'
     static_configs:
     - targets: ['cita_exporter_ip:port']
+    metrics_path: "/metrics/cita"


### PR DESCRIPTION
- 修改代理架构，server通过一个端口去拉取agent数据，原先1920、1921、1922、1923 合并成1920
- 因为修改了端口，所以部署的时候CI上修改prometheus.yml配置文件的sed命令端口要修改为1920