### PR TITLE
fix the new version image and get the CITA version number.

### DIFF
--- a/agent/cita_exporter/Dockerfile
+++ b/agent/cita_exporter/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
   && apt-get install -y  \
 	  python3 \
 	  python3-pip \
+	  libcurl4-openssl-dev \
     && apt-get clean \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- 修复cita-exporter镜像瘦身后无法获取CITA软件版本号的问题
![image](https://user-images.githubusercontent.com/24754263/62096395-22d9c580-b2b6-11e9-81ff-27328553a56c.png)
