### PR TITLE
fix show full pie chart, delete dup ip and port information

### DIFF
--- a/server/grafana/dashboards/CITANodeInfoDashboard.json
+++ b/server/grafana/dashboards/CITANodeInfoDashboard.json
@@ -2129,7 +2129,7 @@
       "format": "bytes",
       "gridPos": {
         "h": 8,
-        "w": 4,
+        "w": 6,
         "x": 0,
         "y": 42
       },
@@ -2191,8 +2191,8 @@
       "fill": 0,
       "gridPos": {
         "h": 8,
-        "w": 9,
-        "x": 4,
+        "w": 7,
+        "x": 6,
         "y": 42
       },
       "hideTimeOverride": false,
@@ -2229,7 +2229,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{NodeIP}}:{{NodePort}} - {{NodeDir}}/logs",
+          "legendFormat": "{{NodeDir}}/logs",
           "refId": "A"
         },
         {
@@ -2237,7 +2237,7 @@
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{NodeIP}}:{{NodePort}} - {{NodeDir}}/data",
+          "legendFormat": "{{NodeDir}}/data",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
* 修复了小型屏幕在默认尺寸下无法显示饼图
* 趋势图在小型屏幕下支持左右拖拽展示数据
* 删除多余的 IP:PORT 信息

![image](https://user-images.githubusercontent.com/35131072/62099610-3b9ba880-b2c1-11e9-9ea8-8bb3f7322e27.png)

