### PR TITLE
show rabbitmq-server process info in Process Info Dashboard

### DIFF
--- a/agent/process_exporter_config/process_list.yml
+++ b/agent/process_exporter_config/process_list.yml
@@ -7,3 +7,6 @@ process_names:
     - cita-chain
     - cita-auth
     - cita-executor
+  - name: "{{.Comm}}"
+    cmdline:
+    - 'rabbitmq-server'


### PR DESCRIPTION
since rabbitmq is a required service of CITA, we need to monitor its status.

here is preview:

![Screen Shot 2019-08-13 at 1 02 20 PM](https://user-images.githubusercontent.com/71397/62916365-b5a45500-bdca-11e9-89c2-9cc60bc30867.png)


![Screen Shot 2019-08-13 at 1 01 41 PM](https://user-images.githubusercontent.com/71397/62916326-8857a700-bdca-11e9-88fd-6d677cbb3e42.png)
