### PR TITLE
fix prometheus not connected  alertmanager

### DIFF
--- a/server/config/prometheus.yml
+++ b/server/config/prometheus.yml
@@ -6,7 +6,7 @@ global:
 alerting:
   alertmanagers:
   - static_configs:
-    - targets: ['cita_monitor_server_alertmanager:9093']
+    - targets: ['citamon_server_alertmanager:9093']
 
 rule_files:
   - 'alert.rules'


### PR DESCRIPTION
- 修复prometheus连不上alertmanager导致不能触发报警

![image](https://user-images.githubusercontent.com/24754263/62921107-49c9e880-bdda-11e9-9d17-9c3010838eb2.png)
